### PR TITLE
Updated Backpack and Rucksack recipe

### DIFF
--- a/common/com/rikmuld/camping/objs/registers/Recipes.scala
+++ b/common/com/rikmuld/camping/objs/registers/Recipes.scala
@@ -45,8 +45,8 @@ object ModRecipes extends ModRegister {
     GameRegistry.addRecipe(nwsk(sleepingBag), " 1 ", "000", '0': Character, nwsk(wool).getWildValue, '1': Character, nwsk(knife).getWildValue)
     GameRegistry.addRecipe(nwsk(sleepingBag), "  1", "000", '0': Character, nwsk(wool).getWildValue, '1': Character, nwsk(knife).getWildValue)
     GameRegistry.addRecipe(nwsk(backpack, 1, ItemDefinitions.Backpack.POUCH), " 0 ", "1 1", "111", '0': Character, string, '1': Character, leather)
-    GameRegistry.addRecipe(nwsk(backpack, 1, ItemDefinitions.Backpack.BACKPACK), " 0 ", "121", "111", '0': Character, string, '1': Character, prts(ItemDefinitions.Parts.CANVAS), '2':Character, nwsk(backpack, 1, ItemDefinitions.Backpack.BACKPACK))
-    GameRegistry.addRecipe(nwsk(backpack, 1, ItemDefinitions.Backpack.RUCKSACK), " 0 ", "121", "111", '0': Character, string, '1': Character, nwsk(animalParts, 1, ItemDefinitions.PartsAnimal.FUR_BROWN), '2':Character, nwsk(backpack, 1, ItemDefinitions.Backpack.RUCKSACK))
+    GameRegistry.addRecipe(nwsk(backpack, 1, ItemDefinitions.Backpack.BACKPACK), " 0 ", "121", "111", '0': Character, string, '1': Character, prts(ItemDefinitions.Parts.CANVAS), '2':Character, nwsk(backpack, 1, ItemDefinitions.Backpack.POUCH))
+    GameRegistry.addRecipe(nwsk(backpack, 1, ItemDefinitions.Backpack.RUCKSACK), " 0 ", "121", "111", '0': Character, string, '1': Character, nwsk(animalParts, 1, ItemDefinitions.PartsAnimal.FUR_BROWN), '2':Character, nwsk(backpack, 1, ItemDefinitions.Backpack.BACKPACK))
     GameRegistry.addShapelessRecipe(prts(Parts.CANVAS), hemp, nwsk(knife).getWildValue)
     for(i <- 0 until 16) GameRegistry.addShapelessRecipe(nwsk(tent, 1, i), nwsk(tent).getWildValue, nwsk(Items.dye, 1, i))
 


### PR DESCRIPTION
Fixed the backpack and rucksack recipes so they don't require themselves in order to craft, which was making the recipes impossible. Backpack now requires a pouch, and rucksack requires a backpack.